### PR TITLE
MHOUSE-653: Honor both tag validation and Validator() implementations simultaneously

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,8 @@
 package validate
 
-import "reflect"
+import (
+	"reflect"
+)
 
 // Validate performs validation on the obj and returns an error if one existed.
 //
@@ -26,8 +28,8 @@ func Validate(obj interface{}, options ...Option) error {
 	}
 
 	ctx := Context{
-		Options:  opts,
-		Value: rval,
+		Options: opts,
+		Value:   rval,
 	}
 
 	return validator.Validate(ctx)


### PR DESCRIPTION
I did a bit of re-writing of the `buildValidator()` so that the way it is handling cases of receivers is correct now that we don't short circuit, and added the relevant testcases for handling all the receiver cases.

I think this should be correct...