### PR TITLE
MHOUSE-563: Add warnings

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -37,7 +37,7 @@ func mergeErrorMessages(errs []error, sep string) string {
 func mergeWarningsAndErrors(warnings []error, errs []error, sep string) (error, error) {
 	var warning error
 	if len(warnings) > 0 {
-		warning = newWarning(mergeErrorMessages(warnings, sep))
+		warning = newError(mergeErrorMessages(warnings, sep))
 	}
 
 	if len(errs) > 0 {
@@ -45,24 +45,6 @@ func mergeWarningsAndErrors(warnings []error, errs []error, sep string) (error, 
 	}
 
 	return nil, warning
-}
-
-func newWarning(msg string) *Warning {
-	return &Warning{Message: msg}
-}
-
-func newWarningf(msg string, args ...interface{}) *Warning {
-	return &Warning{Message: fmt.Sprintf(msg, args...)}
-}
-
-// Warning is a validation warning.
-type Warning struct {
-	Message string
-}
-
-// Warning implements the error interface.
-func (e *Warning) Error() string {
-	return e.Message
 }
 
 func newError(msg string) *Error {

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,18 @@ import (
 	"reflect"
 )
 
+func wrapError(err error, warning bool) error {
+	if err != nil {
+		return nil
+	}
+
+	if warning {
+		return newWarning(err.Error())
+	}
+
+	return newError(err.Error())
+}
+
 func newWarning(msg string) *Warning {
 	return &Warning{Message: msg}
 }
@@ -14,7 +26,6 @@ func newWarningf(msg string, args ...interface{}) *Warning {
 }
 
 // Warning is a validation warning.
-// TODO(may): Can you write this as wrapper for Error?
 type Warning struct {
 	Message string
 }

--- a/errors.go
+++ b/errors.go
@@ -5,8 +5,7 @@ import (
 	"reflect"
 )
 
-// MergeWarning is a convenience function for treating a warning as an error.
-func MergeWarning(err error, warning error) error {
+func mergeWarning(err error, warning error) error {
 	if err == nil && warning == nil {
 		return nil
 	}
@@ -34,7 +33,7 @@ func mergeErrorMessages(errs []error, sep string) string {
 	return errmsg
 }
 
-func mergeWarningsAndErrors(warnings []error, errs []error, sep string) (error, error) {
+func mergeIntoWarningsAndErrors(warnings []error, errs []error, sep string) (error, error) {
 	var warning error
 	if len(warnings) > 0 {
 		warning = newError(mergeErrorMessages(warnings, sep))

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,25 @@ import (
 	"reflect"
 )
 
+func newWarning(msg string) *Warning {
+	return &Warning{Message: msg}
+}
+
+func newWarningf(msg string, args ...interface{}) *Warning {
+	return &Warning{Message: fmt.Sprintf(msg, args...)}
+}
+
+// Warning is a validation warning.
+// TODO(may): Can you write this as wrapper for Error?
+type Warning struct {
+	Message string
+}
+
+// Warning implements the error interface.
+func (e *Warning) Error() string {
+	return e.Message
+}
+
 func newError(msg string) *Error {
 	return &Error{Message: msg}
 }

--- a/options.go
+++ b/options.go
@@ -20,10 +20,14 @@ func defaultOptions() *Options {
 
 // Options holds the options for validation.
 type Options struct {
-	Registry      *Registry
-	StopOnError   bool
-	StopOnWarning bool
-	Validator     Validator
+	Registry         *Registry
+	StopOnError      bool
+	WarningsAsErrors bool
+	Validator        Validator
+}
+
+func (o *Options) shouldStopOnWarnings() bool {
+	return o.StopOnError && o.WarningsAsErrors
 }
 
 // Option provides the ability to alter options.
@@ -37,16 +41,16 @@ func WithRegistry(r *Registry) Option {
 }
 
 // WithStopOnError indicates to the validator to stop when it finds an error.
-func WithStopOnError(stopOnError bool) Option {
+func WithStopOnError() Option {
 	return func(opts *Options) {
 		opts.StopOnError = true
 	}
 }
 
-// WithStopOnWarning indicates to the validator to stop when it finds an error.
-func WithStopOnWarning(stopOnWarning bool) Option {
+// WithWarningsAsErrors indicates that warnings should be treated as errors.
+func WithWarningsAsErrors() Option {
 	return func(opts *Options) {
-		opts.StopOnWarning = true
+		opts.WarningsAsErrors = true
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -20,9 +20,10 @@ func defaultOptions() *Options {
 
 // Options holds the options for validation.
 type Options struct {
-	Registry    *Registry
-	StopOnError bool
-	Validator   Validator
+	Registry      *Registry
+	StopOnError   bool
+	StopOnWarning bool
+	Validator     Validator
 }
 
 // Option provides the ability to alter options.
@@ -39,6 +40,13 @@ func WithRegistry(r *Registry) Option {
 func WithStopOnError(stopOnError bool) Option {
 	return func(opts *Options) {
 		opts.StopOnError = true
+	}
+}
+
+// WithStopOnWarning indicates to the validator to stop when it finds an error.
+func WithStopOnWarning(stopOnWarning bool) Option {
+	return func(opts *Options) {
+		opts.StopOnWarning = true
 	}
 }
 

--- a/tag_validators.go
+++ b/tag_validators.go
@@ -238,11 +238,11 @@ func NotZeroFactory(ctx ResolutionContext, name string, args []string) (Validato
 		return nil, InvalidTagArgumentsError{Message: "no arguments are allowed", ValidatorName: name, Args: args}
 	}
 
-	return ValidatorFunc(func(ctx Context) error {
+	return ValidatorFunc(func(ctx Context) (error, error) {
 		if isZero(ctx.Value) {
-			newErrorf("must not be \"%v\"", zeroValue(ctx.Value.Type()))
+			return newErrorf("must not be \"%v\"", zeroValue(ctx.Value.Type())), nil
 		}
-		return nil
+		return nil, nil
 	}), nil
 }
 

--- a/validate.go
+++ b/validate.go
@@ -32,5 +32,8 @@ func Validate(obj interface{}, options ...Option) (error, error) {
 		Value:   rval,
 	}
 
+	if ctx.Options.WarningsAsErrors {
+		return MergeWarning(validator.Validate(ctx)), nil
+	}
 	return validator.Validate(ctx)
 }

--- a/validate.go
+++ b/validate.go
@@ -4,13 +4,13 @@ import (
 	"reflect"
 )
 
-// Validate performs validation on the obj and returns an error if one existed.
+// Validate performs validation on the obj and returns an error and a warning if it existed, respectively.
 //
 // Example:
 //   if err := validate.Validate(MyObject{}); err != nil {
 //   	// handle validation error
 //   }
-func Validate(obj interface{}, options ...Option) error {
+func Validate(obj interface{}, options ...Option) (error, error) {
 	opts := defaultOptions()
 	for _, option := range options {
 		option(opts)
@@ -23,7 +23,7 @@ func Validate(obj interface{}, options ...Option) error {
 		var err error
 		validator, err = opts.Registry.LookupValidator(rval.Type())
 		if err != nil {
-			return err
+			return err, nil
 		}
 	}
 

--- a/validate.go
+++ b/validate.go
@@ -33,7 +33,15 @@ func Validate(obj interface{}, options ...Option) (error, error) {
 	}
 
 	if ctx.Options.WarningsAsErrors {
-		return MergeWarning(validator.Validate(ctx)), nil
+		return mergeWarning(validator.Validate(ctx)), nil
 	}
 	return validator.Validate(ctx)
+}
+
+// ValidateWarningsAsErrors is the same as Validate(), but returns warnings as
+// errors. This is a convenience function for callers that do not care to
+// distinguish between an error and a warning and therefore do not want to deal
+// two returns.
+func ValidateWarningsAsErrors(obj interface{}, options ...Option) error {
+	return mergeWarning(Validate(obj, options...))
 }

--- a/validators.go
+++ b/validators.go
@@ -216,32 +216,6 @@ func In(values ...interface{}) Validator {
 	})
 }
 
-func mergeErrorMessages(errs []error, sep string) string {
-	paddedSep := fmt.Sprintf(" %s ", sep)
-	if len(errs) == 0 {
-		panic("must provide at least one error")
-	}
-	errmsg := errs[0].Error()
-	for i := 1; i < len(errs); i++ {
-		errmsg += paddedSep + errs[i].Error()
-	}
-
-	return errmsg
-}
-
-func mergeWarningsAndErrors(warnings []error, errs []error, sep string) (error, error) {
-	var warning error
-	if len(warnings) > 0 {
-		warning = newWarning(mergeErrorMessages(warnings, sep))
-	}
-
-	if len(errs) > 0 {
-		return newError(mergeErrorMessages(errs, sep)), warning
-	}
-
-	return nil, warning
-}
-
 // Items validates that all the items of a slice, array.
 func Items(validator Validator) Validator {
 	return ValidatorFunc(func(ctx Context) (error, error) {

--- a/validators.go
+++ b/validators.go
@@ -49,26 +49,7 @@ func And(validators ...Validator) Validator {
 			}
 		}
 
-		var warning error
-		if len(warnings) > 0 {
-			warningmsg := warnings[0].Error()
-			for i := 1; i < len(warnings); i++ {
-				warningmsg += " and " + warnings[i].Error()
-			}
-
-			warning = newWarning(warningmsg)
-		}
-
-		if len(errs) > 0 {
-			errmsg := errs[0].Error()
-			for i := 1; i < len(errs); i++ {
-				errmsg += " and " + errs[i].Error()
-			}
-
-			return newError(errmsg), warning
-		}
-
-		return nil, warning
+		return mergeWarningsAndErrors(warnings, errs, "and")
 	})
 }
 
@@ -235,6 +216,32 @@ func In(values ...interface{}) Validator {
 	})
 }
 
+func mergeErrorMessages(errs []error, sep string) string {
+	paddedSep := fmt.Sprintf(" %s ", sep)
+	if len(errs) == 0 {
+		panic("must provide at least one error")
+	}
+	errmsg := errs[0].Error()
+	for i := 1; i < len(errs); i++ {
+		errmsg += paddedSep + errs[i].Error()
+	}
+
+	return errmsg
+}
+
+func mergeWarningsAndErrors(warnings []error, errs []error, sep string) (error, error) {
+	var warning error
+	if len(warnings) > 0 {
+		warning = newWarning(mergeErrorMessages(warnings, sep))
+	}
+
+	if len(errs) > 0 {
+		return newError(mergeErrorMessages(errs, sep)), warning
+	}
+
+	return nil, warning
+}
+
 // Items validates that all the items of a slice, array.
 func Items(validator Validator) Validator {
 	return ValidatorFunc(func(ctx Context) (error, error) {
@@ -296,27 +303,7 @@ func Items(validator Validator) Validator {
 			return isItemsAllowed(ctx.Value.Type(), "items", nil), nil
 		}
 
-		// De-dup this.
-		var warning error
-		if len(warnings) > 0 {
-			warningmsg := warnings[0].Error()
-			for i := 1; i < len(warnings); i++ {
-				warningmsg += " and " + warnings[i].Error()
-			}
-
-			warning = newWarning(warningmsg)
-		}
-
-		if len(errs) > 0 {
-			msg := errs[0].Error()
-			for i := 1; i < len(errs); i++ {
-				msg += " and " + errs[i].Error()
-			}
-
-			return newError(msg), warning
-		}
-
-		return nil, warning
+		return mergeWarningsAndErrors(warnings, errs, "and")
 	})
 }
 
@@ -579,26 +566,7 @@ func Or(validators ...Validator) Validator {
 			}
 		}
 
-		var warning error
-		if len(warnings) > 0 {
-			warningmsg := warnings[0].Error()
-			for i := 1; i < len(warnings); i++ {
-				warningmsg += " and " + warnings[i].Error()
-			}
-
-			warning = newWarning(warningmsg)
-		}
-
-		if len(errs) > 0 {
-			errmsg := errs[0].Error()
-			for i := 1; i < len(errs); i++ {
-				errmsg += " or " + errs[i].Error()
-			}
-
-			return newError(errmsg), warning
-		}
-
-		return nil, warning
+		return mergeWarningsAndErrors(warnings, errs, "or")
 	})
 }
 

--- a/validators.go
+++ b/validators.go
@@ -245,7 +245,7 @@ func Items(validator Validator) Validator {
 					}
 				}
 				if warning != nil {
-					warnings = append(warnings, newWarningf("[%d] %v", i, warning))
+					warnings = append(warnings, newErrorf("[%d] %v", i, warning))
 					if ctx.Options.shouldStopOnWarnings() {
 						break
 					}
@@ -273,7 +273,7 @@ func Items(validator Validator) Validator {
 					}
 				}
 				if warning != nil {
-					warnings = append(warnings, newWarningf("[%v] %v", mi.Key(), warning))
+					warnings = append(warnings, newErrorf("[%v] %v", mi.Key(), warning))
 					if ctx.Options.shouldStopOnWarnings() {
 						break
 					}

--- a/validators.go
+++ b/validators.go
@@ -43,7 +43,7 @@ func And(validators ...Validator) Validator {
 			}
 			if warning != nil {
 				warnings = append(warnings, warning)
-				if ctx.Options.StopOnWarning {
+				if ctx.Options.shouldStopOnWarnings() {
 					break
 				}
 			}
@@ -264,7 +264,7 @@ func Items(validator Validator) Validator {
 					case *Error:
 						errs = append(errs, newErrorf("[%d] %v", i, err))
 						if ctx.Options.StopOnError {
-							return errs[0], warning
+							break
 						}
 					default:
 						return err, warning
@@ -272,6 +272,9 @@ func Items(validator Validator) Validator {
 				}
 				if warning != nil {
 					warnings = append(warnings, newWarningf("[%d] %v", i, warning))
+					if ctx.Options.shouldStopOnWarnings() {
+						break
+					}
 				}
 			}
 		case reflect.Map:
@@ -289,7 +292,7 @@ func Items(validator Validator) Validator {
 					case *Error:
 						errs = append(errs, newErrorf("[%v] %v", mi.Key(), err))
 						if ctx.Options.StopOnError {
-							return errs[0], warning
+							break
 						}
 					default:
 						return err, warning
@@ -297,6 +300,9 @@ func Items(validator Validator) Validator {
 				}
 				if warning != nil {
 					warnings = append(warnings, newWarningf("[%v] %v", mi.Key(), warning))
+					if ctx.Options.shouldStopOnWarnings() {
+						break
+					}
 				}
 			}
 		default:

--- a/validators.go
+++ b/validators.go
@@ -49,7 +49,7 @@ func And(validators ...Validator) Validator {
 			}
 		}
 
-		return mergeWarningsAndErrors(warnings, errs, "and")
+		return mergeIntoWarningsAndErrors(warnings, errs, "and")
 	})
 }
 
@@ -283,7 +283,7 @@ func Items(validator Validator) Validator {
 			return isItemsAllowed(ctx.Value.Type(), "items", nil), nil
 		}
 
-		return mergeWarningsAndErrors(warnings, errs, "and")
+		return mergeIntoWarningsAndErrors(warnings, errs, "and")
 	})
 }
 
@@ -546,7 +546,7 @@ func Or(validators ...Validator) Validator {
 			}
 		}
 
-		return mergeWarningsAndErrors(warnings, errs, "or")
+		return mergeIntoWarningsAndErrors(warnings, errs, "or")
 	})
 }
 


### PR DESCRIPTION
I think this approach is OK... I'm a little sad about forcing warnings as an extra return but I also added `ValidateWarningsAsErrors()` which should hopefully alleviate the burden of having to handle both return types.
So for those who don't care for distinguishing between warnings and errors:
```go
if err, warning := validate.Validate(&obj); err != nil && warning != nil {
	// Uh-oh!
}
```
Is equivalent to:
```go
if err := validate.ValidateWarningsAsErrors(&obj); err != nil {
	// Uh-oh!
}
```
Obviously, `WarningsAsErrors` does something similar but makes the return signature somewhat unwieldy. This isn't a huge deal, but it's made explicit that the latter is just a convenience function around the former.